### PR TITLE
Rename for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Vaccine Notifier
+# @vaccinesignup
 
-[![test](https://github.com/ivanoblomov/vaccine-notifier/actions/workflows/test.yml/badge.svg)](https://github.com/ivanoblomov/vaccine-notifier/actions/workflows/test.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/dad2d32da2d576e4a99a/maintainability)](https://codeclimate.com/github/ivanoblomov/vaccine-notifier/maintainability)
-[![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/vaccine-notifier/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/ivanoblomov/vaccine-notifier?branch=main)
-[![Inline docs](http://inch-ci.org/github/ivanoblomov/vaccine-notifier.svg?branch=main)](http://inch-ci.org/github/ivanoblomov/vaccine-notifier)
+[![test](https://github.com/ivanoblomov/vaccinesignup/actions/workflows/test.yml/badge.svg)](https://github.com/ivanoblomov/vaccinesignup/actions/workflows/test.yml)
+[![Maintainability](https://api.codeclimate.com/v1/badges/dad2d32da2d576e4a99a/maintainability)](https://codeclimate.com/github/ivanoblomov/vaccinesignup/maintainability)
+[![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/vaccinesignup/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/ivanoblomov/vaccinesignup?branch=main)
+[![Inline docs](http://inch-ci.org/github/ivanoblomov/vaccinesignup.svg?branch=main)](http://inch-ci.org/github/ivanoblomov/vaccinesignup)
 
 This bot notifies LA County users who DM their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine appointments in their area.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/vaccinesignup/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/ivanoblomov/vaccinesignup?branch=main)
 [![Inline docs](http://inch-ci.org/github/ivanoblomov/vaccinesignup.svg?branch=main)](http://inch-ci.org/github/ivanoblomov/vaccinesignup)
 
-This bot notifies LA County users who DM their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine appointments in their area.
+This bot notifies LA County users who DM their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine-appointment Locations in their area.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This bot notifies LA County users who DM their zip codes to [@vaccinesignup](htt
 
    ![zip](https://user-images.githubusercontent.com/113809/111058905-b2b68e00-845f-11eb-99d1-3aa0b4adcaad.png)
 
-3. The bot will DM you available appointments in that zip:
+3. The bot will DM you available Locations in that zip:
 
    ![appointments](https://user-images.githubusercontent.com/113809/111059071-bc8cc100-8460-11eb-9148-74998844b8e9.png)
 

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -28,7 +28,7 @@ class Notifier < ApplicationService
   #           :users => 18
   #     }
   def call
-    results = { clinics: 0, users: 0 }
+    results = { locations: 0, users: 0 }
     @user_zips.each do |user_zip|
       results[:user_zip] = user_zip
       next unless message_for_matching_locations(results)

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -23,7 +23,7 @@ class Notifier < ApplicationService
   # @example
   #   Notifier.call
   #     => {
-  #         :clinics => 10,
+  #         :locations => 10,
   #         :message => ["Appointments now available at:", ...]
   #           :users => 18
   #     }
@@ -37,8 +37,8 @@ class Notifier < ApplicationService
       dm_results(results)
       results[:message] = nil
     end
-    Rails.logger.info "Notified #{results[:users]} users about #{results[:clinics]} appointments."
-    { clinics: results[:clinics], users: results[:users] }
+    Rails.logger.info "Notified #{results[:users]} users about #{results[:locations]} appointments."
+    { clinics: results[:locations], users: results[:users] }
   end
 
   private
@@ -59,7 +59,7 @@ class Notifier < ApplicationService
 #{e.class} when DMing user_id #{results[:user_zip].user_id} with...\n#{results[:message] * "\n"}!
 )
     end
-    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:clinics]} clinics for "\
+    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:locations]} clinics for "\
                       "#{results[:user_zip].zip}."
   end
   # rubocop:enable Metrics/AbcSize
@@ -69,7 +69,7 @@ class Notifier < ApplicationService
       results[:message] ||= DM_HEADER.dup
       results[:message] << clinic_link(clinic)
       results[:message] << nil
-      results[:clinics] += 1
+      results[:locations] += 1
     end
     results[:message]
   end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Notifies users about available appointments in the zips they follow.
+# Notifies users about available Locations in the zips they follow.
 class Notifier < ApplicationService
   DM_HEADER = ['Appointments now available at:', nil].freeze
   DM_FOOTER = "We'll send you available appointments as soon as we're aware. DM 'stop' to cease notifications."
@@ -37,7 +37,7 @@ class Notifier < ApplicationService
       dm_results(results)
       results[:message] = nil
     end
-    Rails.logger.info "Notified #{results[:users]} users about #{results[:locations]} appointments."
+    Rails.logger.info "Notified #{results[:users]} users about #{results[:locations]} Locations."
     { locations: results[:locations], users: results[:users] }
   end
 

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -43,7 +43,7 @@ class Notifier < ApplicationService
 
   private
 
-  def clinic_link(location)
+  def location_entry(location)
     output = ["#{location.name} (#{location.addr1}, #{location.addr2})."]
     output << "Check eligibility and sign-up at #{location.link}" if location.link
     output * "\n"
@@ -67,7 +67,7 @@ class Notifier < ApplicationService
   def message_for_matching_locations(results)
     Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |location|
       results[:message] ||= DM_HEADER.dup
-      results[:message] << clinic_link(location)
+      results[:message] << location_entry(location)
       results[:message] << nil
       results[:locations] += 1
     end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -43,9 +43,9 @@ class Notifier < ApplicationService
 
   private
 
-  def clinic_link(clinic)
-    output = ["#{clinic.name} (#{clinic.addr1}, #{clinic.addr2})."]
-    output << "Check eligibility and sign-up at #{clinic.link}" if clinic.link
+  def clinic_link(location)
+    output = ["#{location.name} (#{location.addr1}, #{location.addr2})."]
+    output << "Check eligibility and sign-up at #{location.link}" if location.link
     output * "\n"
   end
 
@@ -65,9 +65,9 @@ class Notifier < ApplicationService
   # rubocop:enable Metrics/AbcSize
 
   def message_for_matching_locations(results)
-    Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |clinic|
+    Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |location|
       results[:message] ||= DM_HEADER.dup
-      results[:message] << clinic_link(clinic)
+      results[:message] << clinic_link(location)
       results[:message] << nil
       results[:locations] += 1
     end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -19,7 +19,7 @@ class Notifier < ApplicationService
 
   # DMs users about Locations in zip codes they follow.
   #
-  # @return [Hash] the message and number of clinics and users DMd
+  # @return [Hash] the message and number of locations and users DMd
   # @example
   #   Notifier.call
   #     => {
@@ -38,7 +38,7 @@ class Notifier < ApplicationService
       results[:message] = nil
     end
     Rails.logger.info "Notified #{results[:users]} users about #{results[:locations]} appointments."
-    { clinics: results[:locations], users: results[:users] }
+    { locations: results[:locations], users: results[:users] }
   end
 
   private
@@ -59,7 +59,7 @@ class Notifier < ApplicationService
 #{e.class} when DMing user_id #{results[:user_zip].user_id} with...\n#{results[:message] * "\n"}!
 )
     end
-    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:locations]} clinics for "\
+    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:locations]} locations for "\
                       "#{results[:user_zip].zip}."
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -19,7 +19,7 @@ class Notifier < ApplicationService
 
   # DMs users about Locations in zip codes they follow.
   #
-  # @return [Hash] the message and number of locations and users DMd
+  # @return [Hash] the message and number of Locations and users DMd
   # @example
   #   Notifier.call
   #     => {
@@ -59,7 +59,7 @@ class Notifier < ApplicationService
 #{e.class} when DMing user_id #{results[:user_zip].user_id} with...\n#{results[:message] * "\n"}!
 )
     end
-    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:locations]} locations for "\
+    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:locations]} Locations for "\
                       "#{results[:user_zip].zip}."
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/services/notify_bot.rb
+++ b/app/services/notify_bot.rb
@@ -2,7 +2,7 @@
 
 require 'net/http'
 
-# DM users about new appointments.
+# DM users about new Locations.
 class NotifyBot < ApplicationService
   def call
     Notifier.call if DirectMessageReader.call[:subscribed].positive?

--- a/app/services/sync_and_notify_bot.rb
+++ b/app/services/sync_and_notify_bot.rb
@@ -2,7 +2,7 @@
 
 require 'net/http'
 
-# Sync Locations and DM users about new appointment-locations.
+# Sync Locations and DM users about new Locations.
 class SyncAndNotifyBot < ApplicationService
   # Syncs Locations by calling LocationSyncer.call. If any Locations were
   # created/updated, DMs the updates by calling Notifier.call. In either case,

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -29,6 +29,6 @@ namespace :vaccinesignup do
   private
 
   def log_notification_results(results)
-    puts "Notified #{results[:users]} users about #{results[:clinics]} appointments."
+    puts "Notified #{results[:users]} users about #{results[:locations]} appointments."
   end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -29,6 +29,6 @@ namespace :vaccinesignup do
   private
 
   def log_notification_results(results)
-    puts "Notified #{results[:users]} users about #{results[:locations]} appointments."
+    puts "Notified #{results[:users]} users about #{results[:locations]} Locations."
   end
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -16,7 +16,7 @@ describe Notifier do
     context 'when a user subscribes to a matching Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
-      it { should include({ clinics: 1, users: 1 }) }
+      it { should include({ locations: 1, users: 1 }) }
 
       describe 'Rails.logger' do
         context 'when Twitter errors out' do
@@ -52,7 +52,7 @@ describe Notifier do
     context 'when a user subscribes to a non-existing Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90044')] }
 
-      it { should include({ clinics: 0, users: 0 }) }
+      it { should include({ locations: 0, users: 0 }) }
 
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }


### PR DESCRIPTION
# Goal
Use consistent naming for clarity.

# Approach
1. Rename `vaccine-notifier` to `vaccinesignup` for consistent branding.
2. Rename the synonyms `appointments` and `clinics` to `locations` for clarity.
3. When referring to the model, `Location` is capitalized.