### PR TITLE
fix: backup captures current state

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -5,6 +5,7 @@ TEST_USER_ID = 167_894_675
 namespace :vaccinesignup do
   desc 'Back-up production data and restore to the local environment.'
   task back_up: :environment do
+    sh 'heroku pg:backups:capture'
     sh 'heroku pg:backups:download'
     sh 'pg_restore --verbose --clean --no-acl --no-owner -h localhost -d vaccine_notifier latest.dump'
   end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -5,6 +5,7 @@ TEST_USER_ID = 167_894_675
 namespace :vaccinesignup do
   desc 'Back-up production data and restore to the local environment.'
   task back_up: :environment do
+    sh 'rm -f latest.dump'
     sh 'heroku pg:backups:capture'
     sh 'heroku pg:backups:download'
     sh 'pg_restore --verbose --clean --no-acl --no-owner -h localhost -d vaccine_notifier latest.dump'


### PR DESCRIPTION
# Goal
Fix backup task so a backup of the db’s current state is made.

# Approach
1. Remove existing `latest.dump` to insure known state.
2. Call `pg:backups:capture` before downloading.
