### PR TITLE
fix: handle blank (as opposed to nil) links

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -46,7 +46,7 @@ class Location < ApplicationRecord
   # Returns descriptive text for this Location.
   def entry_text
     output = ["#{name} (#{addr1}, #{addr2})."]
-    output << "Check eligibility and sign-up at #{link}" if link
+    output << "Check eligibility and sign-up at #{link}" if link.present?
     output * "\n"
   end
 

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -3,7 +3,7 @@
 # Notifies users about available Locations in the zips they follow.
 class Notifier < ApplicationService
   DM_HEADER = ['Appointments now available at:', nil].freeze
-  DM_FOOTER = "We'll send you available appointments as soon as we're aware. DM 'stop' to cease notifications."
+  DM_FOOTER = "We'll send you updates as soon as we're aware. DM 'stop' to cease notifications."
 
   # Creates a Notifier, setting @user_zips to the specified array of UserZips.
   # Defaults to all existing UserZips.


### PR DESCRIPTION
Closes: #1

# Goal
Don't add link copy when links are blank.

# Approach
1. Add `.present?` to the conditional.
2. Changed "available appointments" to "updates" for clarity.