### PR TITLE
fix: users can follow multiple zips

### DIFF
--- a/app/models/user_zip.rb
+++ b/app/models/user_zip.rb
@@ -2,5 +2,5 @@
 
 # Logs which users are subscribed to which zip codes.
 class UserZip < ApplicationRecord
-  validates_uniqueness_of :user_id, :zip
+  validates_uniqueness_of :user_id, scope: :zip
 end

--- a/spec/models/user_zip_spec.rb
+++ b/spec/models/user_zip_spec.rb
@@ -3,10 +3,10 @@
 # require "#{File.dirname(__FILE__)}/../spec_helper"
 
 describe UserZip do
-  context 'when a user already follows 90044' do
+  context 'when a user already follows a zip' do
     before { UserZip.create(user_id: 1, zip: '90044') }
 
-    context 'when following 90210' do
+    context 'when following another zip' do
       let(:user_zip) { UserZip.new(user_id: 1, zip: '90210') }
 
       describe '#save' do

--- a/spec/models/user_zip_spec.rb
+++ b/spec/models/user_zip_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# require "#{File.dirname(__FILE__)}/../spec_helper"
+
+describe UserZip do
+  context 'when a user already follows 90044' do
+    before { UserZip.create(user_id: 1, zip: '90044') }
+
+    context 'when following 90210' do
+      let(:user_zip) { UserZip.new(user_id: 1, zip: '90210') }
+
+      describe '#save' do
+        subject { user_zip.save }
+
+        it { should be true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes: #55

# Goal
Allow users to follow more than one zip.

# Approach
This is a subtle bug caused by `ActiveRecord.validates_uniqueness_of`. As is `validates_uniqueness_of` will only allow one instance of *either* `UserZip#user_id` or `UserZip#zip`. The net result is that a given user can follow only one zip. What we want instead is for a given user to follow a given zip only once.

1. Cover bug.
2. Scope `#user_id`'s uniqueness to `zip`.