### PR TITLE
fix: ruby-version failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '>= 2.7'
 
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 6.1.3'


### PR DESCRIPTION
# Goal
Fix ["Your Ruby version is 2.7.3, but your Gemfile specified 2.7.2"](https://github.com/ivanoblomov/vaccinesignup/runs/2271910035) failure.

# Approach
Use `>=`.